### PR TITLE
Adding support for elements that have "style" attribute

### DIFF
--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -33,6 +33,18 @@ var getDataset = function getDataset (tag) {
     return dataset;
 };
 
+var parseStyles = function(input) {
+    var attributes = input.split(';');
+    var styles = _.reduce(attributes, function(object, attribute) {
+        var entry = attribute.split(/:(.+)/);
+        if (entry[0] && entry[1]) {
+            object[entry[0].trim()] = entry[1].trim();
+        }
+        return object;
+    }, {});
+    return styles;
+};
+
 module.exports = function createConverter (VNode, VText) {
     var converter = {
         convert: function (node) {
@@ -58,6 +70,10 @@ module.exports = function createConverter (VNode, VText) {
                     attributes[name] = decode(value);
                     return;
                 }
+                if (name === 'style') {
+                    attributes[name] = parseStyles(value);
+                    return;
+                }
                 attributes[name] = value;
             });
 
@@ -65,6 +81,6 @@ module.exports = function createConverter (VNode, VText) {
 
             return new VNode(tag.name, attributes, children);
         }
-    }
+    };
     return converter;
-}
+};

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -41,6 +41,19 @@ describe('htmlparser-to-vdom', function () {
             var converted = convertHTML(html);
             converted.properties.tabIndex.should.equal('1');
         });
+
+        it('parses an div with styles correctly', function () {
+
+            var html = '<div style="top: -7px; left: -6px; background: rgb(0,0,132);"></input>';
+            var styles = {
+                top: '-7px',
+                left: '-6px',
+                background: 'rgb(0,0,132)'
+            };
+
+            var converted = convertHTML(html);
+            converted.properties.style.should.deep.equal(styles);
+        });
     });
 
     describe('when converting a tag with data attributes', function () {

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -44,7 +44,7 @@ describe('htmlparser-to-vdom', function () {
 
         it('parses a div with 1 style correctly', function () {
 
-            var html = '<div style="top: -7px;"></input>';
+            var html = '<div style="top: -7px;"></div>';
             var styles = {
                 top: '-7px'
             };
@@ -55,7 +55,7 @@ describe('htmlparser-to-vdom', function () {
 
         it('parses a div with 1 style without trailing semicolon correctly', function () {
 
-            var html = '<div style="top: -7px"></input>';
+            var html = '<div style="top: -7px"></div>';
             var styles = {
                 top: '-7px'
             };
@@ -66,7 +66,7 @@ describe('htmlparser-to-vdom', function () {
 
         it('parses a div with styles correctly', function () {
 
-            var html = '<div style="top: -7px; left: -6px; background: rgb(0,0,132);"></input>';
+            var html = '<div style="top: -7px; left: -6px; background: rgb(0,0,132);"></div>';
             var styles = {
                 top: '-7px',
                 left: '-6px',
@@ -79,7 +79,7 @@ describe('htmlparser-to-vdom', function () {
 
         it('parses a div with styles without trailing semicolon correctly', function () {
 
-            var html = '<div style="top: -7px; left: -6px; background: rgb(0,0,132)"></input>';
+            var html = '<div style="top: -7px; left: -6px; background: rgb(0,0,132)"></div>';
             var styles = {
                 top: '-7px',
                 left: '-6px',
@@ -92,7 +92,7 @@ describe('htmlparser-to-vdom', function () {
 
         it('parses a div with styles correctly when spaces are missing', function () {
 
-            var html = '<div style="top:-7px;left:-6px;background:rgb(0,0,132);"></input>';
+            var html = '<div style="top:-7px;left:-6px;background:rgb(0,0,132);"></div>';
             var styles = {
                 top: '-7px',
                 left: '-6px',
@@ -105,7 +105,7 @@ describe('htmlparser-to-vdom', function () {
 
         it('parses a div with styles correctly when spaces are abundant', function () {
 
-            var html = '<div style="   top:  -7px  ;    left :  -6px ;   background :  rgb( 0 , 0 , 132 )  ;  "></input>';
+            var html = '<div style="   top:  -7px  ;    left :  -6px ;   background :  rgb( 0 , 0 , 132 )  ;  "></div>';
             var styles = {
                 top: '-7px',
                 left: '-6px',

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -42,7 +42,29 @@ describe('htmlparser-to-vdom', function () {
             converted.properties.tabIndex.should.equal('1');
         });
 
-        it('parses an div with styles correctly', function () {
+        it('parses a div with 1 style correctly', function () {
+
+            var html = '<div style="top: -7px;"></input>';
+            var styles = {
+                top: '-7px'
+            };
+
+            var converted = convertHTML(html);
+            converted.properties.style.should.deep.equal(styles);
+        });
+
+        it('parses a div with 1 style without trailing semicolon correctly', function () {
+
+            var html = '<div style="top: -7px"></input>';
+            var styles = {
+                top: '-7px'
+            };
+
+            var converted = convertHTML(html);
+            converted.properties.style.should.deep.equal(styles);
+        });
+
+        it('parses a div with styles correctly', function () {
 
             var html = '<div style="top: -7px; left: -6px; background: rgb(0,0,132);"></input>';
             var styles = {
@@ -54,6 +76,46 @@ describe('htmlparser-to-vdom', function () {
             var converted = convertHTML(html);
             converted.properties.style.should.deep.equal(styles);
         });
+
+        it('parses a div with styles without trailing semicolon correctly', function () {
+
+            var html = '<div style="top: -7px; left: -6px; background: rgb(0,0,132)"></input>';
+            var styles = {
+                top: '-7px',
+                left: '-6px',
+                background: 'rgb(0,0,132)'
+            };
+
+            var converted = convertHTML(html);
+            converted.properties.style.should.deep.equal(styles);
+        });
+
+        it('parses a div with styles correctly when spaces are missing', function () {
+
+            var html = '<div style="top:-7px;left:-6px;background:rgb(0,0,132);"></input>';
+            var styles = {
+                top: '-7px',
+                left: '-6px',
+                background: 'rgb(0,0,132)'
+            };
+
+            var converted = convertHTML(html);
+            converted.properties.style.should.deep.equal(styles);
+        });
+
+        it('parses a div with styles correctly when spaces are abundant', function () {
+
+            var html = '<div style="   top:  -7px  ;    left :  -6px ;   background :  rgb( 0 , 0 , 132 )  ;  "></input>';
+            var styles = {
+                top: '-7px',
+                left: '-6px',
+                background: 'rgb( 0 , 0 , 132 )'
+            };
+
+            var converted = convertHTML(html);
+            converted.properties.style.should.deep.equal(styles);
+        });
+
     });
 
     describe('when converting a tag with data attributes', function () {


### PR DESCRIPTION
Hi @TimBeyer 

I am trying to use your library into https://github.com/tiagorg/Marionette.VDOMView where I am trying to implement VDOM on Marionette/Backbone Views.

Your library works great, however it doesn't support elements that have "style" attribute, I found that the VirtualDOM element needs to have styles as an object rather than a string, in order for the styles to be properly materialized (created as a real DOM element from the virtual DOM).

So I would like to propose this PR (which would also bump the version) so that mine would be able to start using yours :)

Any question please let me know. Thanks!