### PR TITLE
Add ability to specify a function that determines the key for a VNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,32 @@ var el = createElement(vTree);
 document.body.appendChild(el);
 ```
 
+#### Specifying a key
 In order for `virtual-dom` to detect moves it needs a key. To specify your own custom method of finding a key pass in a method that takes the current tag and returns the key.
 
 ```javascript
 var convertHTML = require('html-to-vdom')({
     VNode: VNode,
-    VText: VText,
-    mapTagToKey: function (tag) {
-    	return tag.attribs.id;
-    }
+    VText: VText
 });
+
+convertHTML('<div id="foo"></div>', {
+	getVNodeKey: function (attributes) {
+		return attributes.id;
+	}
+});
+```
+
+If you have a single key method you can also pass the options first, allowing you to create a single bound method for all key lookups:
+
+```javascript
+var convertHTMLWithKey = convertHTML.bind(null, {
+	getVNodeKey: function (attributes) {
+		return attributes.id;
+	}	
+});
+
+convertHTMLWithKey('<div id="foo"></div>');
 ```
 
 Credits

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ var convertHTML = require('html-to-vdom')({
     VText: VText
 });
 
-convertHTML('<div id="foo"></div>', {
+convertHTML({
     getVNodeKey: function (attributes) {
         return attributes.id;
     }
-});
+}, '<div id="foo"></div>');
 ```
 
 If you have a single key method you can also pass the options first, allowing you to create a single bound method for all key lookups:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ var el = createElement(vTree);
 document.body.appendChild(el);
 ```
 
+In order for `virtual-dom` to detect moves it needs a key. To specify your own custom method of finding a key pass in a method that takes the current tag and returns the key.
+
+```javascript
+var convertHTML = require('html-to-vdom')({
+    VNode: VNode,
+    VText: VText,
+    mapTagToKey: function (tag) {
+    	return tag.attribs.id;
+    }
+});
+```
+
 Credits
 -------
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ var convertHTML = require('html-to-vdom')({
 });
 
 convertHTML('<div id="foo"></div>', {
-	getVNodeKey: function (attributes) {
-		return attributes.id;
-	}
+    getVNodeKey: function (attributes) {
+        return attributes.id;
+    }
 });
 ```
 
@@ -53,9 +53,9 @@ If you have a single key method you can also pass the options first, allowing yo
 
 ```javascript
 var convertHTMLWithKey = convertHTML.bind(null, {
-	getVNodeKey: function (attributes) {
-		return attributes.id;
-	}	
+    getVNodeKey: function (attributes) {
+        return attributes.id;
+    }   
 });
 
 convertHTMLWithKey('<div id="foo"></div>');

--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ module.exports = function initializeConverter (dependencies) {
     if (!dependencies.VNode && !dependencies.VText) {
         throw new Error('html-to-vdom needs to be initialized with VNode and VText');
     }
-    return convertHTML(dependencies.VNode, dependencies.VText);
+    return convertHTML(dependencies.VNode, dependencies.VText, dependencies.mapTagToKey);
 };

--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ module.exports = function initializeConverter (dependencies) {
     if (!dependencies.VNode && !dependencies.VText) {
         throw new Error('html-to-vdom needs to be initialized with VNode and VText');
     }
-    return convertHTML(dependencies.VNode, dependencies.VText, dependencies.mapTagToKey);
+    return convertHTML(dependencies.VNode, dependencies.VText);
 };

--- a/lib/html-to-vdom.js
+++ b/lib/html-to-vdom.js
@@ -1,25 +1,21 @@
 var createConverter = require('./htmlparser-to-vdom');
 var parseHTML = require('./parse-html');
+var _ = require('lodash');
 
 module.exports = function initializeHtmlToVdom (VTree, VText) {
     var htmlparserToVdom = createConverter(VTree, VText);
-    return function convertHTML(html, options) {
-    	// Allow specifying the options as the first argument to allow binding of this function. 
-    	// This is useful to support specifying options to all calls with a single bound function.
-    	if (typeof html !== 'string' && options) {
-    		var args = Array.prototype.slice.call(arguments);
-    		options = args[0];
-    		html = args[1];
-    	}
+    return function convertHTML(options, html) {
+    	var noOptions = _.isUndefined(html) && _.isString(options);
+    	var hasOptions = !noOptions;
 
-        var tags = parseHTML(html);
+    	// was html supplied as the only argument?
+    	var htmlToConvert = noOptions ? options : html;
+    	var getVNodeKey = hasOptions ? options.getVNodeKey : undefined;
 
-        if (options && options.getVNodeKey){
-        	htmlparserToVdom.getVNodeKey = options.getVNodeKey;
-        }
+    	var tags = parseHTML(htmlToConvert);
 
-        var convertedHTML = htmlparserToVdom.convertTag(tags[0]);
-        htmlparserToVdom.getVNodeKey = null;
-        return convertedHTML;
+    	var convertedHTML = htmlparserToVdom.convertTag(tags[0], getVNodeKey);
+
+    	return convertedHTML;
     };
 };

--- a/lib/html-to-vdom.js
+++ b/lib/html-to-vdom.js
@@ -1,10 +1,25 @@
 var createConverter = require('./htmlparser-to-vdom');
 var parseHTML = require('./parse-html');
 
-module.exports = function initializeHtmlToVdom (VTree, VText, mapTagToKey) {
-    var htmlparserToVdom = createConverter(VTree, VText, mapTagToKey);
-    return function convertHTML(html) {
+module.exports = function initializeHtmlToVdom (VTree, VText) {
+    var htmlparserToVdom = createConverter(VTree, VText);
+    return function convertHTML(html, options) {
+    	// Allow specifying the options as the first argument to allow binding of this function. 
+    	// This is useful to support specifying options to all calls with a single bound function.
+    	if (typeof html !== 'string' && options) {
+    		var args = Array.prototype.slice.call(arguments);
+    		options = args[0];
+    		html = args[1];
+    	}
+
         var tags = parseHTML(html);
-        return htmlparserToVdom.convertTag(tags[0]);
+
+        if (options && options.getVNodeKey){
+        	htmlparserToVdom.getVNodeKey = options.getVNodeKey;
+        }
+
+        var convertedHTML = htmlparserToVdom.convertTag(tags[0]);
+        htmlparserToVdom.getVNodeKey = null;
+        return convertedHTML;
     };
 };

--- a/lib/html-to-vdom.js
+++ b/lib/html-to-vdom.js
@@ -1,8 +1,8 @@
 var createConverter = require('./htmlparser-to-vdom');
 var parseHTML = require('./parse-html');
 
-module.exports = function initializeHtmlToVdom (VTree, VText) {
-    var htmlparserToVdom = createConverter(VTree, VText);
+module.exports = function initializeHtmlToVdom (VTree, VText, mapTagToKey) {
+    var htmlparserToVdom = createConverter(VTree, VText, mapTagToKey);
     return function convertHTML(html) {
         var tags = parseHTML(html);
         return htmlparserToVdom.convertTag(tags[0]);

--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -47,15 +47,15 @@ var parseStyles = function(input) {
 
 module.exports = function createConverter (VNode, VText) {
     var converter = {
-        convert: function (node) {
+        convert: function (node, getVNodeKey) {
             if (node.type === 'tag') {
-                return converter.convertTag(node);
+                return converter.convertTag(node, getVNodeKey);
             }
             else if (node.type === 'text') {
                 return new VText(decode(node.data));
             }
         },
-        convertTag: function (tag) {
+        convertTag: function (tag, getVNodeKey) {
             var dataset = getDataset(tag);
             var key;
 
@@ -79,11 +79,13 @@ module.exports = function createConverter (VNode, VText) {
                 attributes[name] = value;
             });
 
-            if (converter.getVNodeKey) {
-                key = converter.getVNodeKey(attributes);
+            if (getVNodeKey) {
+                key = getVNodeKey(attributes);
             }
 
-            var children = _.map(tag.children, converter.convert);
+            var children = _.map(tag.children, function(node) {
+                return converter.convert(node, getVNodeKey);
+            });
 
             return new VNode(tag.name, attributes, children, key);
         }

--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -45,7 +45,7 @@ var parseStyles = function(input) {
     return styles;
 };
 
-module.exports = function createConverter (VNode, VText, mapTagToKey) {
+module.exports = function createConverter (VNode, VText) {
     var converter = {
         convert: function (node) {
             if (node.type === 'tag') {
@@ -79,8 +79,8 @@ module.exports = function createConverter (VNode, VText, mapTagToKey) {
                 attributes[name] = value;
             });
 
-            if (mapTagToKey !== undefined) {
-                key = mapTagToKey(tag);
+            if (converter.getVNodeKey) {
+                key = converter.getVNodeKey(attributes);
             }
 
             var children = _.map(tag.children, converter.convert);

--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -45,7 +45,7 @@ var parseStyles = function(input) {
     return styles;
 };
 
-module.exports = function createConverter (VNode, VText) {
+module.exports = function createConverter (VNode, VText, mapTagToKey) {
     var converter = {
         convert: function (node) {
             if (node.type === 'tag') {
@@ -57,10 +57,12 @@ module.exports = function createConverter (VNode, VText) {
         },
         convertTag: function (tag) {
             var dataset = getDataset(tag);
+            var key;
 
             var attributes = {
                 dataset: dataset
             };
+            
             _.each(tag.attribs, function (value, name) {
                 if (attributesToRename[name]) {
                     attributes[attributesToRename[name]] = value;
@@ -77,9 +79,13 @@ module.exports = function createConverter (VNode, VText) {
                 attributes[name] = value;
             });
 
+            if (mapTagToKey !== undefined) {
+                key = mapTagToKey(tag);
+            }
+
             var children = _.map(tag.children, converter.convert);
 
-            return new VNode(tag.name, attributes, children);
+            return new VNode(tag.name, attributes, children, key);
         }
     };
     return converter;

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -199,15 +199,35 @@ describe('htmlparser-to-vdom', function () {
         it('sets key when specified via mapTagToKey', function () {
             var keyedConvertHTML = require('../../index')({
                 VNode: VNode,
-                VText: VText,
-                mapTagToKey: function (tag) {
-                    return tag.attribs.id;
+                VText: VText
+            });
+
+            var html = '<div id="key1">Test</div>';
+            var converted = keyedConvertHTML(html, {
+                getVNodeKey: function (attribs) {
+                    return attribs.id;
+                }});
+            
+            should.exist(converted.key);
+            converted.key.should.eql('key1');
+        });
+
+        it('allows binding value of getVNodeKey in convertHTML by swapping arguments', function(){
+            var keyedConvertHTML = require('../../index')({
+                VNode: VNode,
+                VText: VText
+            });
+
+            keyedConvertHTML = keyedConvertHTML.bind(null, {
+                getVNodeKey: function (attribs) {
+                    return attribs.id;
                 }
             });
 
             var html = '<div id="key1">Test</div>';
             var converted = keyedConvertHTML(html);
             
+            should.exist(converted.key);
             converted.key.should.eql('key1');
         });
     });

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -203,16 +203,16 @@ describe('htmlparser-to-vdom', function () {
             });
 
             var html = '<div id="key1">Test</div>';
-            var converted = keyedConvertHTML(html, {
+            var converted = keyedConvertHTML({
                 getVNodeKey: function (attribs) {
                     return attribs.id;
-                }});
+                }}, html);
             
             should.exist(converted.key);
             converted.key.should.eql('key1');
         });
 
-        it('allows binding value of getVNodeKey in convertHTML by swapping arguments', function(){
+        it('allows binding value of getVNodeKey in convertHTML', function(){
             var keyedConvertHTML = require('../../index')({
                 VNode: VNode,
                 VText: VText

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -195,6 +195,23 @@ describe('htmlparser-to-vdom', function () {
         });
     });
 
+    describe('when specifying a custom method for key', function () {
+        it('sets key when specified via mapTagToKey', function () {
+            var keyedConvertHTML = require('../../index')({
+                VNode: VNode,
+                VText: VText,
+                mapTagToKey: function (tag) {
+                    return tag.attribs.id;
+                }
+            });
+
+            var html = '<div id="key1">Test</div>';
+            var converted = keyedConvertHTML(html);
+            
+            converted.key.should.eql('key1');
+        });
+    });
+
     describe('when converting a label containing the `for` attribute', function () {
         it('sets the htmlFor attribute correspondingly', function () {
             var html = '<label for="foobar"></label>';


### PR DESCRIPTION
We use some attributes to denote our elements, something such as a data-uuid="4423424" for all of our elements. Adding the ability to specify the key on the node allows the patches to detect moves instead of just diffs. That is useful in our case as in addition to just doing the diffing we want to inspect the patches to highlight the changes.