### PR TITLE
Remove lodash dependency for a leaner build

### DIFF
--- a/lib/html-to-vdom.js
+++ b/lib/html-to-vdom.js
@@ -1,11 +1,10 @@
 var createConverter = require('./htmlparser-to-vdom');
 var parseHTML = require('./parse-html');
-var _ = require('lodash');
 
 module.exports = function initializeHtmlToVdom (VTree, VText) {
     var htmlparserToVdom = createConverter(VTree, VText);
     return function convertHTML(options, html) {
-    	var noOptions = _.isUndefined(html) && _.isString(options);
+    	var noOptions = typeof html === 'undefined' && typeof options === 'string';
     	var hasOptions = !noOptions;
 
     	// was html supplied as the only argument?

--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -17,12 +17,15 @@ var attributesToRename = {
 
 var getDataset = function getDataset (tag) {
     var attributes = tag.attribs;
-    if (_.isEmpty(attributes)) {
+    if (typeof attributes === 'undefined' ||
+        attributes === null ||
+        Object.keys(attributes).length === 0) {
         return {};
     }
 
     var dataset = {};
-    _.each(attributes, function (value, name) {
+    Object.keys(attributes).forEach(function (name) {
+        var value = attributes[name];
         if (!(/^data-/).test(name)) {
             return;
         }
@@ -35,13 +38,13 @@ var getDataset = function getDataset (tag) {
 
 var parseStyles = function(input) {
     var attributes = input.split(';');
-    var styles = _.reduce(attributes, function(object, attribute) {
+    var styles = attributes.reduce(function(object, attribute){
         var entry = attribute.split(/:(.+)/);
         if (entry[0] && entry[1]) {
             object[entry[0].trim()] = entry[1].trim();
         }
         return object;
-    }, {});
+    },{});
     return styles;
 };
 
@@ -62,8 +65,10 @@ module.exports = function createConverter (VNode, VText) {
             var attributes = {
                 dataset: dataset
             };
-            
-            _.each(tag.attribs, function (value, name) {
+
+            Object.keys(tag.attribs).forEach(function (name) {
+                var value = tag.attribs[name];
+
                 if (attributesToRename[name]) {
                     attributes[attributesToRename[name]] = value;
                     return;
@@ -83,7 +88,7 @@ module.exports = function createConverter (VNode, VText) {
                 key = getVNodeKey(attributes);
             }
 
-            var children = _.map(tag.children, function(node) {
+            var children = Array.prototype.map.call(tag.children || [], function(node) {
                 return converter.convert(node, getVNodeKey);
             });
 

--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -1,5 +1,4 @@
 var decode = require('ent').decode;
-var _ = require('lodash');
 
 var prefixLength = ('data-').length;
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "homepage": "https://github.com/TimBeyer/html-to-vdom",
   "dependencies": {
     "ent": "^2.0.0",
-    "htmlparser2": "^3.8.2",
-    "lodash": "^2.4.1"
+    "htmlparser2": "^3.8.2"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
Hi, we're optimizing the JS load and parse times for a single page app, it would be really useful if lodash was left out of the dependency tree. I think you used lodash.each(), .map() and .reduce() for compatibility reasons? I switched them to use the Array.prototype equivalent in my fork.