### PR TITLE
Transform hyphenated data attributes to valid dataset key names

### DIFF
--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -14,6 +14,15 @@ var attributesToRename = {
     'tabindex': 'tabIndex'
 };
 
+// Transform a data attribute name to a valid dataset key name
+// (See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement.dataset)
+var dataAttributeToDatasetKey = function dataAttributeToDatasetKey (name) {
+    var unprefixed = name.slice(prefixLength);
+    return unprefixed.replace(/\-([a-z])/g, function (m, charAfterHyphen) {
+        return charAfterHyphen.toUpperCase();
+    });
+};
+
 var getDataset = function getDataset (tag) {
     var attributes = tag.attribs;
     if (typeof attributes === 'undefined' ||
@@ -28,8 +37,7 @@ var getDataset = function getDataset (tag) {
         if (!(/^data-/).test(name)) {
             return;
         }
-        var unprefixed = name.slice(prefixLength);
-        dataset[unprefixed] = value;
+        dataset[dataAttributeToDatasetKey(name)] = value;
     });
 
     return dataset;

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -132,6 +132,20 @@ describe('htmlparser-to-vdom', function () {
             converted.properties['data-test'].should.eql('foobar');
         });
 
+        it('converts a single hyphenated data attribute correctly', function () {
+
+            var html = '<div data-test-data="foobar"></div>';
+
+            var converted = convertHTML(html);
+
+            should.exist(converted.properties.dataset.testData);
+            converted.properties.dataset.testData.should.eql('foobar');
+
+            should.exist(converted.properties['data-test-data']);
+            converted.properties['data-test-data'].should.eql('foobar');
+
+        });
+
          it('converts multiple data attributes correctly', function () {
 
             var html = '<div data-test="foobar" data-foobar="test"></div>';


### PR DESCRIPTION
This fixes an error that occurs when attempting to create a virtual-dom tree from HTML containing `data-`-prefixed attributes with hyphens in their names. Without this, the dataset passed in to virtual-dom has invalid names (e.g. `element-uid` instead of `elementUid`) and Node or the browser fails to set the dataset properties.