### PR TITLE
Custom attributes should be set on the "attributes" property

### DIFF
--- a/lib/html-to-vdom.js
+++ b/lib/html-to-vdom.js
@@ -4,17 +4,21 @@ var parseHTML = require('./parse-html');
 module.exports = function initializeHtmlToVdom (VTree, VText) {
     var htmlparserToVdom = createConverter(VTree, VText);
     return function convertHTML(options, html) {
-    	var noOptions = typeof html === 'undefined' && typeof options === 'string';
-    	var hasOptions = !noOptions;
+        var noOptions = typeof html === 'undefined' && typeof options === 'string';
+        var hasOptions = !noOptions;
 
-    	// was html supplied as the only argument?
-    	var htmlToConvert = noOptions ? options : html;
-    	var getVNodeKey = hasOptions ? options.getVNodeKey : undefined;
+        // was html supplied as the only argument?
+        var htmlToConvert = noOptions ? options : html;
+        var getVNodeKey = hasOptions ? options.getVNodeKey : undefined;
 
-    	var tags = parseHTML(htmlToConvert);
+        var tags = parseHTML(htmlToConvert);
 
-    	var convertedHTML = htmlparserToVdom.convertTag(tags[0], getVNodeKey);
+        if (tags.length > 1) {
+            throw new Error('Input must always have only one root node. You cannot convert multiple siblings without a wrapping tag around them.');
+        }
 
-    	return convertedHTML;
+        var convertedHTML = htmlparserToVdom.convert(tags[0], getVNodeKey);
+
+        return convertedHTML;
     };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-vdom",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Converts html into a vtree",
   "main": "index.js",
   "scripts": {

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -8,8 +8,25 @@ var convertHTML = require('../../index')({
 
 describe('htmlparser-to-vdom', function () {
 
-    describe('when converting a tag', function () {
+    describe('when converting a single text node', function () {
+        it('parses the text node correctly', function () {
+            var html = 'test';
 
+            var converted = convertHTML(html);
+            converted.text.should.eql('test');
+        });
+    });
+
+    describe('when converting multiple sibling nodes without a wrapper', function () {
+        it('throws', function () {
+            var html = '    <div></div>';
+
+            should.throw(convertHTML.bind(null, html), 'Input must always have only one root node. You cannot convert multiple siblings without a wrapping tag around them.');
+        });
+
+    });
+
+    describe('when converting a tag', function () {
         it('parses a plain div correctly', function () {
 
             var html = '<div></div>';


### PR DESCRIPTION
I was exploring serialization and deserialization via this library and [vdom-to-html](), and there appears to be an inconsistency in the way custom attributes are parsed. After checking how the DOM renders elements created via virtual-dom's createElement, I believe the correct solution is to set custom attributes in the attributes hash when creating a new VNode.

Some more background here: https://github.com/nthtran/vdom-to-html/issues/6