### PR TITLE
add support for scripts and style tags, add tests for unsupported node types

### DIFF
--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -58,11 +58,13 @@ var parseStyles = function(input) {
 module.exports = function createConverter (VNode, VText) {
     var converter = {
         convert: function (node, getVNodeKey) {
-            if (node.type === 'tag') {
+            if (node.type === 'tag' || node.type === 'script' || node.type === 'style') {
                 return converter.convertTag(node, getVNodeKey);
-            }
-            else if (node.type === 'text') {
+            } else if (node.type === 'text') {
                 return new VText(decode(node.data));
+            } else {
+                // converting an unsupported node, return an empty text node instead.
+                return new VText('');
             }
         },
         convertTag: function (tag, getVNodeKey) {

--- a/test/html-to-vdom/index.js
+++ b/test/html-to-vdom/index.js
@@ -300,4 +300,59 @@ describe('htmlparser-to-vdom', function () {
             converted.properties.title.should.eql('"test"');
         });
     });
+
+    describe('when converting HTML containing a script tag', function () {
+        it('converts to a virtualdom node', function () {
+            var html = '<div><script src="foo.js">alert("bar!");</script></div>';
+            var converted = convertHTML(html);
+            var script = converted.children[0];
+            should.exist(script);
+            script.tagName.should.eql('script');
+            script.children.length.should.eql(1);
+            script.children[0].text.should.eql('alert("bar!");');
+        });
+    });
+
+    describe('when converting HTML containing a style tag', function () {
+        it('converts to a virtualdom node', function () {
+            var html = '<div><style>h1 {color:red;} p {color:blue;} </style></div>';
+            var converted = convertHTML(html);
+            var script = converted.children[0];
+            should.exist(script);
+            script.tagName.should.eql('style');
+            script.children.length.should.eql(1);
+            script.children[0].text.should.eql('h1 {color:red;} p {color:blue;} ');
+        });
+    });
+
+    describe('when converting HTML containing CDATA', function () {
+        it('returns an empty string instead (cdata is unsupported)', function () {
+            var html = '<![CDATA[ Within this Character Data block I can\
+                        use double dashes as much as I want (along with <, &, \', and ")\
+                        *and* %MyParamEntity; will be expanded to the text\
+                        "Has been expanded" ... however, I can\'t use\
+                        the CEND sequence (if I need to use it I must escape one of the\
+                        brackets or the greater-than sign).\
+                        ]]>';
+            var converted = convertHTML(html);
+            converted.text.should.eql('');
+        });
+    });
+
+    describe('when converting HTML containing a directive', function () {
+        it('returns an empty string instead (directives are unsupported)', function () {
+            var html = '<!DOCTYPE html>';
+            var converted = convertHTML(html);
+            converted.text.should.eql('');
+        });
+    });
+
+    describe('when converting HTML containing a comment', function () {
+        it('returns an empty string instead (comments are unsupported)', function () {
+            var html = '<div><!-- some comment --></div>';
+            var converted = convertHTML(html);
+            var comment = converted.children[0];
+            comment.text.should.eql('');
+        });
+    });
 });


### PR DESCRIPTION
I came across a case where undefined nodes would be returned from `convert`, because it only would parse if the node was either type 'tag' or 'text'.

This caused issues when trying to use vtree-select and other libraries, as VNode trees are assumed to not contain children that are `undefined`.

After some digging, it looks like htmlparser2 has xmlMode turned on by default, so `script` and `style` tags would be `undefined`. Additionally, directives like `doctype` don't seem to be supported by virtual-hyperscript, along with comments and CDATA (which is treated like a comment by htmlparser2).

The intent of this pull is to solve 2 problems:

1. adds tests so that a consumer can easily understand what DOM elements will and will not be parsed by this library
2. return empty VText nodes instead of undefined nodes, so the output of this library can always be consumed by libraries that assume VTrees only contain VNode/VText children.